### PR TITLE
Pass --region param to describe-instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ A nice & easy way to create on demand R Clusters on AWS with:
 - `sh create_cluster.sh`
 - `sh create_rstudio.sh`
 
+## Update
+
+- `sh update_nodes.sh`: to update the node ip list, e.g. when cluster is restarted.
+
 ## Reference
 
 - `sh create_cluster.sh`: This script will send all these files to an S3 bucket, and then generates the R-Cluster via de `aws cli`

--- a/others/update_nodes.sh
+++ b/others/update_nodes.sh
@@ -1,3 +1,3 @@
 INSTANCE_HASH=$(curl -s http://169.254.169.254/latest/meta-data/security-groups | grep -oE "[^-]+$")
-aws ec2 describe-instances --filters "Name=tag-value,Values=SlaveRCluster-"$INSTANCE_HASH | jq '.Reservations[].Instances[].NetworkInterfaces[].PrivateIpAddress' > nodes.txt
+aws ec2 describe-instances --filters "Name=tag-value,Values=SlaveRCluster-"$INSTANCE_HASH --region $AWS_REGION | jq '.Reservations[].Instances[].NetworkInterfaces[].PrivateIpAddress' > nodes.txt
 sed 's/\"//g' nodes.txt -i nodes.txt


### PR DESCRIPTION
This PR fixes a missing parameter:

```
You must specify a region. You can also configure your region by running "aws configure".
```

Now to run you can either
- pass a AWS_REGION variable or
- set your environment using `aws configure`; so the script picks the default AWS_REGION value.

```sh
AWS_REGION=us-west-2 sh update_nodes.sh
```